### PR TITLE
Add: Photo 상세 모달 창 구현

### DIFF
--- a/public/Data/cardData.json
+++ b/public/Data/cardData.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+    {
+      "id": 0,
+      "url": "https://images.unsplash.com/photo-1522093007474-d86e9bf7ba6f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80",
+      "user_img": "https://images.unsplash.com/profile-1558839302636-86b1b07991ef?dpr=1&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff 1x, https://images.unsplash.com/profile-1558839302636-86b1b07991ef?dpr=2&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff 2x",
+      "width": 1600,
+      "height": 2000,
+      "user_id": "Jenny Nana",
+      "like_pressed": "ture",
+      "collections_added": "false"
+    },
+    {
+      "id": 1,
+      "url": "https://images.unsplash.com/photo-1596199737455-0b2e92661915?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&w=1000&q=80",
+      "user_img": "https://images.unsplash.com/profile-1520092527688-c4068ef9ecda?dpr=1&auto=format&fit=crop&w=150&h=150&q=60&crop=faces&bg=fff",
+      "width": 1000,
+      "height": 562,
+      "user_id": "Earth",
+      "like_pressed": "ture",
+      "collections_added": "false"
+    },
+    {
+      "id": 2,
+      "url": "https://images.unsplash.com/photo-1596190113009-73e5fdf25038?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80",
+      "user_img": "https://images.unsplash.com/profile-1589953304731-68767026aaa2image?dpr=1&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff",
+      "width": 1498,
+      "height": 834,
+      "user_id": "Dylan Leagh",
+      "like_pressed": "true",
+      "collections_added": "false"
+    },
+    {
+      "id": 3,
+      "url": "https://images.unsplash.com/photo-1596187511608-8c8e03ddb4a8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1576&q=80",
+      "user_img": "https://images.unsplash.com/profile-1520487878912-084601c4b155?dpr=1&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff",
+      "width": 1576,
+      "height": 2100,
+      "user_id": "Holger Link",
+      "like_pressed": "false",
+      "collections_added": "false"
+    },
+    {
+      "id": 4,
+      "url": "https://images.unsplash.com/photo-1596195985766-ed92f3ec64eb?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1548&q=80",
+      "user_img": "https://images.unsplash.com/profile-1587392666196-30bffffa512dimage?dpr=1&auto=format&fit=crop&w=150&h=150&q=60&crop=faces&bg=fff",
+      "width": 1548,
+      "height": 1196,
+      "user_id": "Nighthawk Shoots",
+      "like_pressed": "false",
+      "collections_added": "true"
+    },
+    {
+      "id": 5,
+      "url": "https://images.unsplash.com/photo-1532173311168-91e999ce4e47?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1001&q=80",
+      "user_img": "https://images.unsplash.com/profile-fb-1531154942-43162dbf7a8a.jpg?dpr=1&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff",
+      "width": 1001,
+      "height": 1251,
+      "user_id": "Meor Mohamad",
+      "like_pressed": "true",
+      "collections_added": "true"
+    },
+    {
+      "id": 6,
+      "url": "https://images.unsplash.com/photo-1587365001066-8263b7061a38?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80",
+      "user_img": "https://images.unsplash.com/profile-fb-1517893906-f7dbcae2a5cd.jpg?dpr=1&auto=format&fit=crop&w=32&h=32&q=60&crop=faces&bg=fff",
+      "width": 1050,
+      "height": 700,
+      "user_id": "Gleb Mishin",
+      "like_pressed": "false",
+      "collections_added": "true"
+    }
+  ]
+}

--- a/public/Data/tempCardData.json
+++ b/public/Data/tempCardData.json
@@ -1,0 +1,13 @@
+{
+  "data": [
+    {
+      "id": 1,
+      "image": "https://images.unsplash.com/photo-1596206494156-2ef1898d58a7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80",
+      "location": "Zermatt, Schweiz",
+      "user_first_name": "doori",
+      "user_last_name": "kim",
+      "user_profile_image": "https://ca.slack-edge.com/TH0U6FBTN-ULWL5HMSA-117648a3d11c-512",
+      "user_name": "dooreplay"
+    }
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,7 @@
       console.log(Kakao.isInitialized());
     </script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Weplash | Beautiful Free Images & Pictures</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/Component/Card/Card.js
+++ b/src/Component/Card/Card.js
@@ -2,10 +2,10 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import CardTopBtns from "./CardTopBtns";
 import CardUser from "./CardUser";
+import CollectionModal from "../Collection/CollectionModal";
 
-const Card = ({ card, color, id }) => {
+const Card = ({ card, color, id, onClickModal, userCardState }) => {
   const [show, setShow] = useState(false);
-  const height = (card.height * 416) / card.width;
 
   const options = { thershold: 1.0 };
   const observer = new IntersectionObserver((entries, observer) => {
@@ -20,28 +20,53 @@ const Card = ({ card, color, id }) => {
     observer.observe(img);
   });
 
+  const [collectionModalActive, setCollectionModalActive] = useState(false);
+
   return (
-    <CardFrame height={Math.round(height, 0)} color={color[id]}>
-      {
-        <div
-          onMouseEnter={() => setShow(true)}
-          onMouseLeave={() => setShow(false)}
-        >
-          {show && (
-            <div className="hover">
-              <CardTopBtns data={card} img={card.image} id={id} />
-              <CardUser data={card} />
-            </div>
-          )}
-          <img alt="" className="imageCard" src={card.image} color={color} />
-        </div>
-      }
+    // <CardFrame color={color[id]}>
+    <CardFrame>
+      <div
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+      >
+        {show && (
+          <CardTopBtns
+            data={card}
+            img={card.image}
+            id={id}
+            setCollectionModalActive={setCollectionModalActive}
+            collectionModalActive={collectionModalActive}
+          />
+        )}
+        {show && <CardUser data={card} userCardState={userCardState} />}
+        {show && <HoverStyle onClick={() => onClickModal(card.id, id)} />}
+        <img alt="" className="imageCard" src={card.image} color={color} />
+      </div>
+      {collectionModalActive && (
+        <CollectionModal
+          collectionModalActive={collectionModalActive}
+          setCollectionModalActive={setCollectionModalActive}
+        />
+      )}
     </CardFrame>
   );
 };
 
 export default Card;
 
+const HoverStyle = styled.div`
+  position: absolute;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-self: flex-start;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  transition: 0.2s;
+`;
 const CardFrame = styled.figure`
   position: relative;
   display: inline-block;
@@ -50,21 +75,8 @@ const CardFrame = styled.figure`
   margin-bottom: 23px;
   cursor: zoom-in;
 
-  .hover {
-    position: absolute;
-    display: flex;
-    justify-content: space-between;
-    align-self: flex-start;
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.3);
-    transition: 0.2s;
-  }
-
   .imageCard {
-    display: block;
+    /* display: block; */
     width: 100%;
     height: ${(props) => `${props.height}px`};
     background-color: ${(props) => props.color};

--- a/src/Component/Card/CardList.js
+++ b/src/Component/Card/CardList.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { TopicCardsAPI } from "../../config";
 import Card from "./Card";
+import Modal from "../Modal/Modal";
 import Loading from "../Loading";
 
 const CardList = () => {
@@ -9,6 +10,12 @@ const CardList = () => {
   const [colors, setColors] = useState([]);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(false);
+  //Modal
+  const [isModalActive, setModalActive] = useState(false);
+  const [cardData, setCardData] = useState([]);
+  const [cardIndex, setCardIndex] = useState(0);
+  const [photoId, setPhotoId] = useState(0);
+  /////
   const prevOffset = useRef(0);
   const LIMIT = 20;
 
@@ -18,6 +25,7 @@ const CardList = () => {
       .then((res) => {
         setColors(res.data);
       });
+    //eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -28,6 +36,7 @@ const CardList = () => {
       .then((res) => {
         setCards(res.data);
       });
+    //eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const checkScrollHeight = () => {
@@ -69,23 +78,67 @@ const CardList = () => {
     }
   };
 
+  //Modal
+  const handleModal = (idx) => {
+    setModalActive(!isModalActive);
+    setCardIndex(idx);
+    // isModalActive && setCardData(originCardData);
+  };
+
+  const handleIndex = (newIdx) => {
+    setCardIndex(newIdx);
+    setPhotoId(cardData[newIdx].id);
+  };
+
+  const handleOpenModal = (photoId, idx) => {
+    handleModal(idx);
+    setPhotoId(photoId);
+  };
+
+  useEffect(() => {
+    isModalActive
+      ? (document.body.style.overflow = "hidden")
+      : (document.body.style.overflow = "unset");
+  }, [isModalActive]);
+
+  useEffect(() => {
+    setCardData(cards);
+  }, [cards]);
+  /////
+
   return (
-    <CardListFrame>
-      {loading && <Loading load={loading} />}
-      {cards &&
-        cards.map((card, id) => {
-          return (
-            <Card
-              key={id}
-              id={id}
-              card={card}
-              color={colors.map((color) => {
-                return color.background_color;
-              })}
-            />
-          );
-        })}
-    </CardListFrame>
+    <>
+      <CardListFrame>
+        {loading && <Loading load={loading} />}
+        {cards &&
+          cards.map((card, id) => {
+            return (
+              <Card
+                key={id}
+                id={id}
+                card={card}
+                color={colors.map((color) => {
+                  return color.background_color;
+                })}
+                onClickModal={handleOpenModal}
+                isModalActive={isModalActive}
+                userCardState={true}
+              />
+            );
+          })}
+      </CardListFrame>
+      {isModalActive && cardData.length > 0 && (
+        <Modal
+          handleModal={handleModal}
+          cardData={cardData}
+          setCardData={setCardData}
+          cardIndex={cardIndex}
+          setCardIndex={setCardIndex}
+          handleIndex={handleIndex}
+          photoId={photoId}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/Component/Card/CardTopBtns.js
+++ b/src/Component/Card/CardTopBtns.js
@@ -7,7 +7,11 @@ const {
   colors: { grayColor, redColor },
 } = theme;
 
-const CardTopBtns = ({ img }) => {
+const CardTopBtns = ({
+  img,
+  collectionModalActive,
+  setCollectionModalActive,
+}) => {
   const [like, setLikeBtn] = useState(false);
   const handleLikeBtn = () => {
     setLikeBtn(!like);
@@ -24,6 +28,7 @@ const CardTopBtns = ({ img }) => {
   const [collect, setCollectBtn] = useState(false);
   const handleCollectBtn = () => {
     setCollectBtn(!collect);
+    setCollectionModalActive(!collectionModalActive);
     // fetch(collectAPI, {
     //   method: "POST",
     //   headers: {
@@ -56,8 +61,8 @@ const CardTopBtns = ({ img }) => {
 export default CardTopBtns;
 
 const CardTopBtnsFrame = styled.div`
-  z-index: 3;
   position: absolute;
+  z-index: 10;
   display: flex;
   top: 20px;
   right: 20px;

--- a/src/Component/Card/CardUser.js
+++ b/src/Component/Card/CardUser.js
@@ -4,7 +4,7 @@ import { downloadBtnSvg } from "../../icons";
 import UserCard from "../UserCard/UserCard";
 import theme from "../../Styles/StyleTheme";
 
-const CardUser = ({ data }) => {
+const CardUser = ({ data, userCardState }) => {
   const [show, setShow] = useState(false);
 
   return (
@@ -14,7 +14,7 @@ const CardUser = ({ data }) => {
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
       >
-        {show && (
+        {show && userCardState && (
           <UserCard
             cardUserId={data.user_name}
             cardUserName={data.user_first_name + data.user_last_name}
@@ -42,6 +42,9 @@ const {
 } = theme;
 
 const CardUserFrame = styled.div`
+  position: absolute;
+  bottom: 0px;
+  z-index: 10;
   display: flex;
   width: 100%;
   align-items: flex-end;

--- a/src/Component/Collection/Collection.js
+++ b/src/Component/Collection/Collection.js
@@ -1,0 +1,119 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import HashTag from "../Modal/Buttons/HashTag";
+
+const Collection = ({ collection }) => {
+  return (
+    <Container>
+      <div className="imageWrap">
+        <div className="imageBox">
+          <Link>
+            <div className="imageWrap">
+              <div className="left">
+                <img
+                  src="https://images.unsplash.com/photo-1542108613-4c236d7eb28d?ixlib=rb-1.2.1&auto=format&fit=crop&w=750&q=60"
+                  alt="item"
+                />
+              </div>
+              <div className="right">
+                <div className="rightTop">
+                  <img
+                    src="https://images.unsplash.com/photo-1524090485940-4ded7244c483?ixlib=rb-1.2.1&auto=format&fit=crop&w=750&q=60"
+                    alt="item"
+                  />
+                </div>
+                <div className="rightBottom">
+                  <img src={collection.image[0]} alt="item" />
+                </div>
+              </div>
+            </div>
+            <div className="title">
+              <div>Once upon a World</div>
+            </div>
+            <div className="copyWrite">
+              <div>{collection.photos_number} photos</div>
+              <span>· Curated by </span>
+              <span>{collection.user_first_name}</span>
+            </div>
+          </Link>
+        </div>
+      </div>
+      <div className="tagBox">
+        {collection.tags.map((tag, i) => {
+          return <HashTag tag={tag} key={i} />;
+        })}
+      </div>
+    </Container>
+  );
+};
+
+export default Collection;
+
+// Styled Components
+
+const Container = styled.div`
+  width: 416px;
+  height: 403px;
+
+  .imageWrap {
+    border-radius: 4px;
+    overflow: hidden;
+
+    .imageBox {
+      width: 416px;
+      height: 356.19px;
+
+      .imageWrap {
+        display: flex;
+        height: 291.19px;
+        margin-bottom: 16px;
+
+        &:hover {
+          filter: alpha(opacity=80);
+          opacity: 0.9;
+          transition: 0.2s;
+        }
+
+        .left {
+          width: 70%;
+          margin-right: 2px;
+          overflow: hidden;
+        }
+
+        .right {
+          width: 30%;
+
+          .rightTop {
+            height: 50%;
+            margin-bottom: 2px;
+            overflow: hidden;
+          }
+
+          .rightBottom {
+            height: 50%;
+          }
+        }
+      }
+
+      .title {
+        margin-bottom: 8px;
+        color: #111;
+      }
+
+      .copyWrite {
+        display: flex;
+        font-size: 14px;
+        color: #767676;
+        margin-bottom: 13px;
+      }
+    }
+  }
+
+  .tagBox {
+    display: flex;
+    flex-direction: flex-start;
+    width: 416px;
+    height: 34px;
+  }
+`;

--- a/src/Component/Collection/CollectionModal.js
+++ b/src/Component/Collection/CollectionModal.js
@@ -1,39 +1,40 @@
 import React from "react";
 import styled from "styled-components";
+import Dimmer from "../Dimmer";
 
-const CollectionModal = ({ img }) => {
-  console.log(img);
+const CollectionModal = ({ img, setCollectionModalActive }) => {
   return (
     <CollectionModalFrame>
       <div className="collectionModal">
-        <div className="collectionTitle" src={img} />
+        <div className="collectionTitle" img={img} />
         <div className="">
           <h3>Add to Collection</h3>
           <button>Create a new Collection</button>
           {/* <CollectionCard /> */}
         </div>
       </div>
+      <Dimmer setCollectionModalActive={setCollectionModalActive} />
     </CollectionModalFrame>
   );
 };
 export default CollectionModal;
 
 const CollectionModalFrame = styled.div`
-  position: absolute;
-  background-color: rgba(0, 0, 0, 0.4);
-
   .collectionModal {
+    position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
     width: 990px;
     height: 560px;
     background-color: white;
+    z-index: 20;
     .collectionTitle {
+      position: fixed;
       width: 333px;
       height: 560px;
       overflow: hidden;
-      background-image: ${(props) => `url("${props.src}")`};
+      background-image: ${(props) => `url("${props.img}")`};
       background-size: cover;
     }
   }

--- a/src/Component/Dimmer.js
+++ b/src/Component/Dimmer.js
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "styled-components";
+
+const DimmerContainer = styled.div`
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+  z-index: 5;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 35px 6vw 100px;
+`;
+
+const Dimmer = ({ setCollectionModalActive }) => {
+  return <DimmerContainer onClick={() => setCollectionModalActive()} />;
+};
+
+export default Dimmer;

--- a/src/Component/Modal/Buttons/AddIcon.js
+++ b/src/Component/Modal/Buttons/AddIcon.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { collectBtnSvg } from "../../../icons";
+
+const AddIcon = () => {
+  const [addState, setAddState] = useState(false);
+
+  return (
+    <Container AddState={addState}>
+      <button>{collectBtnSvg}</button>
+    </Container>
+  );
+};
+
+export default AddIcon;
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 4px;
+
+  button {
+    ${(props) => props.theme.btnCustom};
+    width: 39px;
+    height: 32px;
+    fill: ${(props) => (props.AddState ? "#fff" : "#767676")};
+    background-color: ${(props) => (props.AddState ? "#3cb46e" : "#fff")};
+    border: 1px solid ${(props) => (props.AddState ? "transparent" : "#d1d1d1")};
+    border-radius: 4px;
+    &:hover {
+      border: 1px solid ${(props) => (props.AddState ? "none" : "#111")};
+      fill: ${(props) => (props.AddState ? "#fff" : "#111")};
+      background-color: ${(props) => (props.AddState ? "#2eab62" : "#fff")};
+    }
+  }
+
+  svg {
+    position: relative;
+    width: 15px;
+  }
+`;

--- a/src/Component/Modal/Buttons/BtnClose.js
+++ b/src/Component/Modal/Buttons/BtnClose.js
@@ -1,0 +1,46 @@
+import React from "react";
+import styled from "styled-components";
+
+const BtnClose = ({ handleModal }) => {
+  return (
+    <Container>
+      <button onClick={handleModal}>
+        <svg
+          width="32"
+          height="32"
+          className="_3p8U1"
+          version="1.1"
+          viewBox="0 0 32 32"
+          aria-hidden="false"
+        >
+          <path d="M25.33 8.55l-1.88-1.88-7.45 7.45-7.45-7.45-1.88 1.88 7.45 7.45-7.45 7.45 1.88 1.88 7.45-7.45 7.45 7.45 1.88-1.88-7.45-7.45z"></path>
+        </svg>
+      </button>
+    </Container>
+  );
+};
+
+export default BtnClose;
+
+// Styled Components
+
+const Container = styled.div`
+  position: absolute;
+  margin-top: -25px;
+  margin-left: -5.5vw;
+
+  button {
+    ${(props) => props.theme.btnCustom}
+    position: fixed;
+    opacity: 0.8;
+
+    svg {
+      width: 24px;
+      height: 24px;
+      fill: #d1d1d1;
+      &:hover {
+        fill: #fff;
+      }
+    }
+  }
+`;

--- a/src/Component/Modal/Buttons/BtnDirection.js
+++ b/src/Component/Modal/Buttons/BtnDirection.js
@@ -1,0 +1,70 @@
+import React from "react";
+import styled from "styled-components";
+
+const BtnDirection = ({ cardIndex, cardLength, handleIndex }) => {
+  const handlePrevious = () => {
+    cardIndex > 0 && handleIndex(cardIndex - 1);
+  };
+
+  const handleNext = () => {
+    cardIndex < cardLength - 1 && handleIndex(cardIndex + 1);
+  };
+
+  return (
+    <Container>
+      <div onClick={handlePrevious}>
+        <svg
+          width="32"
+          height="32"
+          className="_2tKOW"
+          version="1.1"
+          viewBox="0 0 32 32"
+          aria-hidden="false"
+        >
+          <path d="M20.6667 24.6666l-2 2L8 16 18.6667 5.3333l2 2L12 16l8.6667 8.6666z"></path>
+        </svg>
+      </div>
+      <div onClick={handleNext}>
+        <svg
+          width="32"
+          height="32"
+          className="_2tKOW"
+          version="1.1"
+          viewBox="0 0 32 32"
+          aria-hidden="false"
+        >
+          <path d="M11.3333 7.3333l2-2L24 16 13.3333 26.6666l-2-2L20 16l-8.6667-8.6667z"></path>
+        </svg>
+      </div>
+    </Container>
+  );
+};
+
+export default BtnDirection;
+
+// Styled Components
+
+const Container = styled.div`
+  position: fixed;
+  display: flex;
+  justify-content: space-between;
+  top: 45%;
+  width: 100%;
+  left: 0;
+
+  div {
+    opacity: 0.8;
+    /* padding: 80px 44px; */
+    padding: 6vh 2.2vw;
+    cursor: pointer;
+
+    svg {
+      width: 32px;
+      height: 32px;
+      fill: #d1d1d1;
+      &:hover {
+        fill: #fff;
+      }
+    }
+  }
+`;

--- a/src/Component/Modal/Buttons/Buttons.js
+++ b/src/Component/Modal/Buttons/Buttons.js
@@ -1,0 +1,26 @@
+import React from "react";
+import styled from "styled-components";
+import Heart from "./HeartIcon";
+import Add from "./AddIcon";
+import DownloadIcon from "./DownloadIcon";
+
+const Buttons = () => {
+  return (
+    <Container>
+      <Heart />
+      <Add />
+      <DownloadIcon />
+    </Container>
+  );
+};
+
+export default Buttons;
+
+// Styled Components
+
+const Container = styled.div`
+  display: flex;
+  width: 226.67px;
+  height: 40px;
+  background-color: #fff;
+`;

--- a/src/Component/Modal/Buttons/DownloadIcon.js
+++ b/src/Component/Modal/Buttons/DownloadIcon.js
@@ -1,0 +1,85 @@
+import React from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+const DownloadIcon = () => {
+  return (
+    <Container>
+      <div className="wrap">
+        <Link>
+          <span>Download</span>
+        </Link>
+        <DropDown>
+          <button>
+            <svg
+              width="32"
+              height="32"
+              className="fpkc9"
+              version="1.1"
+              viewBox="0 0 32 32"
+              aria-hidden="false"
+            >
+              <path d="M9.9 11.5l6.1 6.1 6.1-6.1 1.9 1.9-8 8-8-8 1.9-1.9z"></path>
+            </svg>
+          </button>
+        </DropDown>
+      </div>
+    </Container>
+  );
+};
+
+export default DownloadIcon;
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 4px;
+
+  .wrap {
+    display: flex;
+    border: 1px solid #d1d1d1;
+    border-radius: 4px;
+  }
+
+  a {
+    ${(props) => props.theme.flexCenter};
+    width: 89.67px;
+    height: 32px;
+    padding: 0 11px;
+    &:hover {
+      border-top-left-radius: 4px;
+      border-bottom-left-radius: 4px;
+      border: 1px solid #111;
+    }
+
+    span {
+      color: #767676;
+      font-size: 14px;
+      font-weight: 500;
+      &:hover {
+        color: #111;
+      }
+    }
+  }
+`;
+
+const DropDown = styled.div`
+  button {
+    ${(props) => props.theme.btnCustom};
+    width: 34px;
+    height: 32px;
+    fill: #767676;
+    border-left: 1px solid #d1d1d1;
+    &:hover {
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+      border: 1px solid #111;
+      fill: #111;
+    }
+  }
+
+  svg {
+    width: 32px;
+    height: 24px;
+  }
+`;

--- a/src/Component/Modal/Buttons/HashTag.js
+++ b/src/Component/Modal/Buttons/HashTag.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const HashTag = (props) => {
+  return (
+    <Container>
+      <Link>{props.tag}</Link>
+    </Container>
+  );
+};
+
+export default HashTag;
+
+// Styled Components
+
+const Container = styled.div`
+  height: 34px;
+  padding-bottom: 8px;
+  padding-right: 8px;
+
+  a {
+    color: #767676;
+    background-color: #eee;
+    padding: 0 8px;
+    border-radius: 2px;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 26px;
+  }
+`;

--- a/src/Component/Modal/Buttons/HeartIcon.js
+++ b/src/Component/Modal/Buttons/HeartIcon.js
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { likeBtnSvg } from "../../../icons";
+
+const HeartIcon = () => {
+  const [likeState, setLikeState] = useState(false);
+
+  return (
+    <Container likeState={likeState}>
+      <button onClick={() => setLikeState(!likeState)}>{likeBtnSvg}</button>
+    </Container>
+  );
+};
+
+export default HeartIcon;
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 4px;
+
+  button {
+    ${(props) => props.theme.btnCustom};
+    width: 39px;
+    height: 32px;
+    fill: ${(props) => (props.likeState ? "#fff" : "#767676")};
+    background-color: ${(props) => (props.likeState ? "#f15151" : "#fff")};
+    border: 1px solid
+      ${(props) => (props.likeState ? "transparent" : "#d1d1d1")};
+    border-radius: 4px;
+    &:hover {
+      border: 1px solid ${(props) => (props.likeState ? "none" : "#111")};
+      fill: ${(props) => (props.likeState ? "#fff" : "#111")};
+      background-color: ${(props) => (props.likeState ? "#d61313" : "#fff")};
+    }
+  }
+
+  svg {
+    position: relative;
+    width: 15px;
+  }
+`;

--- a/src/Component/Modal/Buttons/InfoIcon.js
+++ b/src/Component/Modal/Buttons/InfoIcon.js
@@ -1,0 +1,70 @@
+import React from "react";
+import styled from "styled-components";
+
+const InfoIcon = () => {
+  return (
+    <Container>
+      <button>
+        <div className="wrap">
+          <svg
+            width="32"
+            height="32"
+            className="_1rYbs"
+            version="1.1"
+            viewBox="0 0 32 32"
+            aria-hidden="false"
+          >
+            <path d="M16 0c-8.8 0-16 7.2-16 16s7.2 16 16 16 16-7.2 16-16-7.2-16-16-16zm2 25c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1v-12c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v12zm0-16c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1v-2c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v2z"></path>
+          </svg>
+          <span>Info</span>
+        </div>
+      </button>
+    </Container>
+  );
+};
+
+export default InfoIcon;
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 4px;
+
+  button {
+    ${(props) => props.theme.btnCustom};
+    border: 1px solid #d1d1d1;
+    width: 79.2px;
+    height: 32px;
+    fill: #767676;
+    padding: 0 11px;
+    border-radius: 4px;
+    &:hover {
+    }
+
+    .wrap {
+      height: 100%;
+      display: flex;
+      align-items: center;
+
+      span {
+        color: #767676;
+        font-size: 14px;
+        font-weight: 500;
+        margin-left: 6px;
+        &:hover {
+          color: #111;
+        }
+      }
+    }
+    &:hover {
+      border: 1px solid #111;
+      fill: #111;
+      color: #111;
+    }
+  }
+
+  svg {
+    height: 14px;
+    width: 14px;
+  }
+`;

--- a/src/Component/Modal/Buttons/ShareIcon.js
+++ b/src/Component/Modal/Buttons/ShareIcon.js
@@ -1,0 +1,68 @@
+import React from "react";
+import styled from "styled-components";
+
+const ShareIcon = () => {
+  return (
+    <Container>
+      <button>
+        <div className="wrap">
+          <svg
+            width="32"
+            height="32"
+            className="_1xhtJ"
+            version="1.1"
+            viewBox="0 0 32 32"
+            aria-hidden="false"
+          >
+            <path d="M0 26c0 1.7.2 3.3.6 4.9.2.9.7.9 1 0 2.1-5.3 5.5-10.3 11.1-11.3h3.3v4.4c0 2 1.2 2.6 2.6 1.4l12.8-11c.7-.6.7-1.6 0-2.3l-12.8-11c-1.4-1.3-2.6-.6-2.6 1.3v4.7c-9.6 1.6-16 9.4-16 18.9z"></path>
+          </svg>
+          <span>Share</span>
+        </div>
+      </button>
+    </Container>
+  );
+};
+
+export default ShareIcon;
+
+// Styled Components
+
+const Container = styled.div`
+  padding: 4px;
+
+  button {
+    ${(props) => props.theme.btnCustom};
+    border: 1px solid #d1d1d1;
+    width: 90.38px;
+    height: 32px;
+    fill: #767676;
+    padding: 0 11px;
+    border-radius: 4px;
+    &:hover {
+      border: 1px solid #111;
+      fill: #111;
+      color: #111;
+    }
+
+    .wrap {
+      height: 100%;
+      display: flex;
+      align-items: center;
+
+      span {
+        color: #767676;
+        font-size: 14px;
+        font-weight: 500;
+        margin-left: 6px;
+        &:hover {
+          color: #111;
+        }
+      }
+    }
+  }
+
+  svg {
+    height: 14px;
+    width: 14px;
+  }
+`;

--- a/src/Component/Modal/Dimmer.js
+++ b/src/Component/Modal/Dimmer.js
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+import BtnClose from "./Buttons/BtnClose";
+
+const DimmerContainer = styled.div`
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 35px 6vw 100px;
+`;
+
+const Dimmer = (props) => {
+  return (
+    <DimmerContainer>
+      <BtnClose />
+    </DimmerContainer>
+  );
+};
+
+export default Dimmer;

--- a/src/Component/Modal/Modal.js
+++ b/src/Component/Modal/Modal.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect, useRef } from "react";
+import styled from "styled-components";
+import BtnClose from "./Buttons/BtnClose";
+import ModalContents from "./ModalContents/ModalContents";
+import API_URL from "../../api";
+
+const Modal = ({
+  photoId,
+  handleModal,
+  cardData,
+  cardIndex,
+  setCardData,
+  handleIndex,
+  setCardIndex,
+  isModalActive,
+}) => {
+  const [relatedPhotos, setRelatedPhotos] = useState([]);
+  const [relatedTags, setRelatedTags] = useState([]);
+  const [relatedCollections, setRelatedCollections] = useState([]);
+
+  useEffect(() => {
+    handleRelatedInfo();
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [photoId]);
+
+  const scrollToTop = useRef();
+
+  const handleRelatedInfo = () => {
+    setRelatedPhotos([]);
+    handleScrollToTop();
+
+    fetch(`${API_URL}/photo/related-photo/${photoId}`)
+      .then((res) => res.json())
+      .then((res) => {
+        setRelatedTags(res.tags);
+        setRelatedPhotos(res.data);
+      });
+
+    fetch(`${API_URL}/photo/related-collection/22`)
+      .then((res) => res.json())
+      .then((res) => {
+        setRelatedCollections(res.data);
+      });
+  };
+
+  const handleScrollToTop = () => {
+    scrollToTop.current.scrollTo(0, 0, { behavior: "smooth" });
+  };
+
+  const handleModalClose = (e) => {
+    if (e.target !== e.currentTarget) return;
+    handleModal();
+  };
+
+  return (
+    <Dimmer onClick={(e) => handleModalClose(e)} ref={scrollToTop}>
+      <BtnClose handleModal={handleModal} />
+      <ModalContents
+        cardData={cardData}
+        cardIndex={cardIndex}
+        setCardData={setCardData}
+        relatedPhotos={relatedPhotos}
+        relatedTags={relatedTags}
+        relatedCollections={relatedCollections}
+        setCardIndex={setCardIndex}
+        handleIndex={handleIndex}
+        handleScrollToTop={handleScrollToTop}
+        isModalActive={isModalActive}
+      />
+    </Dimmer>
+  );
+};
+
+export default Modal;
+
+const Dimmer = styled.div`
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+  z-index: 100;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: 35px 6vw 100px;
+`;
+
+// const Loader = styled.div`
+//   position: fixed;
+//   top: 50%;
+//   left: 50%;
+//   z-index: 0;
+//   display: ${(props) => !props.isLoaderActive && "none"};
+// `;

--- a/src/Component/Modal/ModalContents/ModalContents.js
+++ b/src/Component/Modal/ModalContents/ModalContents.js
@@ -1,0 +1,254 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import Buttons from "../Buttons/Buttons";
+import Share from "../Buttons/ShareIcon";
+import InfoIcon from "../Buttons/InfoIcon";
+import RelatedContents from "./RelatedContents/RelatedContents";
+import BtnDirection from "../Buttons/BtnDirection";
+
+const ModalContent = ({
+  cardData,
+  cardIndex,
+  setCardData,
+  relatedTags,
+  relatedPhotos,
+  relatedCollections,
+  setCardIndex,
+  handleScrollToTop,
+  handleIndex,
+  isLoaderActive,
+  isModalActive,
+}) => {
+  const [isImgFull, setImgFull] = useState(false);
+
+  useEffect(() => {
+    setImgFull(false);
+  }, [cardIndex]);
+
+  return (
+    <>
+      <BtnDirection
+        cardIndex={cardIndex}
+        handleIndex={handleIndex}
+        cardLength={cardData.length}
+      />
+      <ContainerWrap>
+        <Container>
+          <div>
+            <HeaderContainer>
+              <header>
+                <Left>
+                  <span>
+                    <div className="profileImg">
+                      <Link to="/">
+                        <img
+                          src={cardData[cardIndex].user_profile_image}
+                          alt="profile"
+                        />
+                      </Link>
+                    </div>
+                    <div className="profileInfo">
+                      <div className="name">
+                        {cardData[cardIndex].user_name}
+                      </div>
+                      <div className="tag">
+                        @{cardData[cardIndex].user_first_name}
+                      </div>
+                    </div>
+                  </span>
+                </Left>
+                <Buttons />
+              </header>
+            </HeaderContainer>
+            <ImgContainer isImgFull={isImgFull}>
+              <div>
+                <img
+                  onClick={() => setImgFull(!isImgFull)}
+                  src={cardData[cardIndex].image}
+                  alt="item"
+                />
+              </div>
+            </ImgContainer>
+          </div>
+          <Bottom>
+            <LocationInfo locationExistence={cardData[cardIndex].location}>
+              <div>
+                <svg
+                  width="32"
+                  height="32"
+                  className="_15of1"
+                  version="1.1"
+                  viewBox="0 0 32 32"
+                  aria-hidden="false"
+                >
+                  <path d="M16 0c-6.7 0-12 5.3-12 12 0 8.6 8.6 17.3 11.2 19.7.4.4 1.1.4 1.5 0 2.7-2.4 11.3-11.1 11.3-19.7 0-6.7-5.3-12-12-12zm0 18c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"></path>
+                </svg>
+                <span>{cardData[cardIndex].location}</span>
+              </div>
+              <p>
+                <span>
+                  {cardData[cardIndex].location === "Null"
+                    ? "Photo"
+                    : cardData[cardIndex].location}
+                </span>
+                <span> by {cardData[cardIndex].user_first_name}</span>
+                <span>{cardData[cardIndex].user_last_name}</span>
+                <span>
+                  (@
+                  {cardData[cardIndex].user_name})
+                </span>
+              </p>
+            </LocationInfo>
+            <Share></Share>
+            <InfoIcon></InfoIcon>
+          </Bottom>
+
+          <RelatedContents
+            relatedTags={relatedTags}
+            relatedPhotos={relatedPhotos}
+            relatedCollections={relatedCollections}
+            setCardData={setCardData}
+            setCardIndex={setCardIndex}
+            handleScrollToTop={handleScrollToTop}
+            isLoaderActive={isLoaderActive}
+            isModalActive={isModalActive}
+          />
+        </Container>
+      </ContainerWrap>
+    </>
+  );
+};
+
+export default ModalContent;
+
+// Styled Components
+
+const ContainerWrap = styled.div`
+  ${(props) => props.theme.flexCenter};
+  border-radius: 4px;
+  width: 100%;
+  min-height: 100%;
+  background-color: #fff;
+  z-index: 10;
+  scroll-behavior: smooth;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-bottom: 80px;
+`;
+
+const HeaderContainer = styled.div`
+  height: 60px;
+  background-color: #fff;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  position: sticky;
+  top: -35px;
+  z-index: 1;
+
+  header {
+    display: flex;
+    align-items: center;
+    padding: 9px 12px;
+  }
+`;
+
+const Left = styled.div`
+  margin-right: auto;
+
+  span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .profileImg {
+      margin-right: 8px;
+    }
+
+    .profileInfo {
+      line-height: 1.35;
+
+      .name {
+        font-size: 15px;
+        font-weight: 500;
+      }
+
+      .tag {
+        font-size: 11px;
+        letter-spacing: 0.02em;
+        color: #767676;
+      }
+    }
+  }
+
+  a {
+    img {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      overflow: hidden;
+    }
+  }
+`;
+
+const ImgContainer = styled.div`
+  padding: ${(props) => (props.isImgFull ? "0" : "10px 16px")};
+
+  div {
+    display: flex;
+    justify-content: center;
+    min-width: ${(props) => (props.isImgFull ? "100%" : "400px")};
+    max-width: calc((100vh - 175px) * 0.8);
+    margin: 0 auto;
+
+    img {
+      width: 100%;
+      height: 100%;
+      max-height: ${(props) => (props.isImgFull ? "100%" : "1131px")};
+      cursor: ${(props) => (props.isImgFull ? "zoom-out" : "zoom-in")};
+    }
+  }
+`;
+
+const Bottom = styled.div`
+  display: flex;
+  height: 80px;
+  padding: 9px 12px;
+  background-color: inherit;
+
+  div {
+    padding: 4px;
+  }
+`;
+
+const LocationInfo = styled.div`
+  line-height: 1.6;
+  margin-right: auto;
+
+  div {
+    display: ${(props) =>
+      props.locationExistence === "Null" ? "none" : "block"};
+    font-size: 12px;
+    &:hover {
+      text-decoration: underline;
+    }
+
+    svg {
+      box-sizing: initial;
+      height: 13px;
+      width: 13px;
+      fill: #c1c1c1;
+      margin-right: 6px;
+      margin-bottom: 1px;
+    }
+  }
+
+  p {
+    font-size: 12px;
+    font-weight: 400;
+    color: #767676;
+  }
+`;

--- a/src/Component/Modal/ModalContents/RelatedContents/RelatedCollections.js
+++ b/src/Component/Modal/ModalContents/RelatedContents/RelatedCollections.js
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+import Collection from "../../../Collection/Collection";
+
+const RelatedCollections = ({ relatedCollections }) => {
+  return (
+    <Container>
+      <Title>Related collections</Title>
+      <CollectionsContainer>
+        {relatedCollections.map((collection, i) => {
+          return <Collection collection={collection} key={i} />;
+        })}
+      </CollectionsContainer>
+    </Container>
+  );
+};
+
+export default RelatedCollections;
+
+// Styled Components
+
+const Container = styled.div`
+  margin: 12px;
+`;
+
+const Title = styled.p`
+  max-width: 100%;
+  height: 104px;
+  padding-top: 60px;
+  padding-bottom: 16px;
+  margin: 12px;
+  font-size: 18px;
+`;
+
+const CollectionsContainer = styled.div`
+  margin: 0 12px 12px 12px;
+`;

--- a/src/Component/Modal/ModalContents/RelatedContents/RelatedContents.js
+++ b/src/Component/Modal/ModalContents/RelatedContents/RelatedContents.js
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "styled-components";
+import RelatedCollections from "./RelatedCollections";
+import RelatedTags from "./RelatedTags";
+import RelatedPhotos from "./RelatedPhotos";
+
+const RelatedContents = ({
+  relatedPhotos,
+  setCardData,
+  setCardIndex,
+  handleScrollToTop,
+  relatedCollections,
+  relatedTags,
+  isLoaderActive,
+  isModalActive,
+}) => {
+  return (
+    <Container>
+      <RelatedPhotos
+        relatedPhotos={relatedPhotos}
+        setCardData={setCardData}
+        setCardIndex={setCardIndex}
+        handleScrollToTop={handleScrollToTop}
+        isLoaderActive={isLoaderActive}
+        isModalActive={isModalActive}
+      />
+      <RelatedCollections relatedCollections={relatedCollections} />
+      <RelatedTags relatedTags={relatedTags} />
+    </Container>
+  );
+};
+
+export default RelatedContents;
+
+const Container = styled.div`
+  max-width: 1320px;
+  margin: 0 auto;
+`;

--- a/src/Component/Modal/ModalContents/RelatedContents/RelatedPhotos.js
+++ b/src/Component/Modal/ModalContents/RelatedContents/RelatedPhotos.js
@@ -1,0 +1,76 @@
+import React, { useRef } from "react";
+import styled from "styled-components";
+import Card from "../../../Card/Card";
+
+const RelatedPhotos = ({
+  relatedPhotos,
+  setCardData,
+  setCardIndex,
+  handleScrollToTop,
+  isLoaderActive,
+  isModalActive,
+}) => {
+  const handleMoveToNewCard = (nothing, i) => {
+    console.log("넌 불리고 있니?", nothing, i);
+    handleScrollToTop();
+    setCardData(relatedPhotos);
+    setCardIndex(i);
+  };
+
+  const selectCurrentTarget = useRef();
+
+  return (
+    <Container>
+      <Title>Related Photos</Title>
+      <CardWrap>
+        {relatedPhotos.map((photo, i) => {
+          return (
+            <div className="card" ref={selectCurrentTarget} key={i}>
+              <Card
+                card={photo}
+                id={i}
+                isModalActive={isModalActive}
+                onClickModal={handleMoveToNewCard}
+                userCardState={false}
+              />
+            </div>
+          );
+        })}
+        <Loader id="여기가 로더" isLoaderActive={isLoaderActive}>
+          <div className="ui active inline loader"></div>
+        </Loader>
+      </CardWrap>
+    </Container>
+  );
+};
+
+export default RelatedPhotos;
+
+const Container = styled.div`
+  margin: 12px;
+  overflow: hidden;
+`;
+
+const Title = styled.p`
+  max-width: 100%;
+  height: 104px;
+  padding-top: 60px;
+  padding-bottom: 16px;
+  margin: 12px;
+  font-size: 18px;
+`;
+
+const CardWrap = styled.div`
+  width: 1320px;
+  margin: 0 auto;
+  column-width: 416px;
+  column-gap: 5px;
+`;
+
+const Loader = styled.div`
+  /* position: fixed;
+  top: 50%;
+  left: 50%; */
+  z-index: 10;
+  display: ${(props) => !props.isLoaderActive && "none"};
+`;

--- a/src/Component/Modal/ModalContents/RelatedContents/RelatedTags.js
+++ b/src/Component/Modal/ModalContents/RelatedContents/RelatedTags.js
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "styled-components";
+import HashTag from "../../Buttons/HashTag";
+
+const RelatedTags = ({ relatedTags }) => {
+  return (
+    <Container>
+      <Title>Related Tags</Title>
+      <div className="tagBox">
+        {relatedTags.map((tag, i) => {
+          return <HashTag tag={tag} key={i} />;
+        })}
+      </div>
+    </Container>
+  );
+};
+
+export default RelatedTags;
+
+// Styled Components
+
+const Container = styled.div`
+  margin: 12px;
+
+  .tagBox {
+    display: flex;
+    flex-direction: flex-start;
+    margin: 12px;
+    flex-wrap: wrap;
+  }
+`;
+
+const Title = styled.p`
+  max-width: 100%;
+  height: 104px;
+  padding-top: 60px;
+  padding-bottom: 16px;
+  margin: 12px;
+  font-size: 18px;
+`;

--- a/src/Component/Modal/ModalPage.js
+++ b/src/Component/Modal/ModalPage.js
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "styled-components";
+import ModalContent from "./ModalContent/ModalContents";
+
+const ModalPage = ({ cardData, cardIndex }) => {
+  return (
+    <Container>
+      <ModalContent cardData={cardData} cardIndex={cardIndex} />
+    </Container>
+  );
+};
+
+export default ModalPage;
+
+// Styled Components
+
+const Container = styled.div`
+  ${(props) => props.theme.flexCenter};
+  border-radius: 4px;
+  width: 100%;
+  min-height: 100%;
+  background-color: #fff;
+`;

--- a/src/Component/Nav/CategoriesNav.js
+++ b/src/Component/Nav/CategoriesNav.js
@@ -5,7 +5,7 @@ import { navData } from "./navData";
 
 const Category = ({ category }) => {
   return (
-    <Link>
+    <Link to="/">
       <li>{category}</li>
     </Link>
   );
@@ -18,8 +18,8 @@ const CategoriesNav = () => {
     <CategoryContainer>
       <Left>
         <ul>
-          {editorials.map((category) => {
-            return <Category category={category} />;
+          {editorials.map((category, i) => {
+            return <Category category={category} key={i} />;
           })}
         </ul>
       </Left>
@@ -27,8 +27,8 @@ const CategoriesNav = () => {
       <Categories>
         <div>
           <ul>
-            {categories.map((category) => {
-              return <Category category={category} />;
+            {categories.map((category, i) => {
+              return <Category category={category} key={i} />;
             })}
           </ul>
         </div>

--- a/src/Component/Nav/HeaderNav.js
+++ b/src/Component/Nav/HeaderNav.js
@@ -10,7 +10,7 @@ const HeaderNav = () => {
     <header>
       <NavContainer>
         <SearchContainer>
-          <Link>{HomeSvg}</Link>
+          <Link to="/">{HomeSvg}</Link>
           <SearchBar inputBg={inputBg}>
             <form>
               <button>{SearchSvg}</button>
@@ -25,10 +25,10 @@ const HeaderNav = () => {
         <HomeContainer className="2">
           <ul>
             <li>
-              <Link>Home</Link>
+              <Link to="/">Home</Link>
             </li>
             <li>
-              <Link>Topics</Link>
+              <Link to="/">Topics</Link>
             </li>
             <li className="dots">
               <div>

--- a/src/Pages/Main/Main.js
+++ b/src/Pages/Main/Main.js
@@ -1,8 +1,76 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { withRouter } from "react-router-dom";
+import Modal from "../../Component/Modal/Modal";
+import API_URL from "../../api";
 
 const Main = () => {
-  return <div>Main</div>;
+  const [isModalActive, setModalActive] = useState(false);
+  const [cardData, setCardData] = useState([]);
+  const [originCardData, setOriginCardData] = useState([]);
+  const [cardIndex, setCardIndex] = useState(0);
+  const [photoId, setPhotoId] = useState(0);
+
+  const handleModal = (idx) => {
+    setModalActive(!isModalActive);
+    setCardIndex(idx);
+    // isModalActive && setCardData(originCardData);
+  };
+
+  const handleIndex = (newIdx) => {
+    setCardIndex(newIdx);
+    setPhotoId(cardData[newIdx].id);
+  };
+
+  const handleOpenModal = (photoId, idx) => {
+    handleModal(idx);
+    setPhotoId(photoId);
+  };
+
+  useEffect(() => {
+    isModalActive
+      ? (document.body.style.overflow = "hidden")
+      : (document.body.style.overflow = "unset");
+  }, [isModalActive]);
+
+  //서버연결
+  useEffect(() => {
+    fetch(`${API_URL}/photo?category=Travel`)
+      .then((res) => res.json())
+      .then((res) => {
+        setOriginCardData(res.data);
+        setCardData(res.data);
+      });
+  }, []);
+
+  return (
+    <>
+      <div>
+        {originCardData.map((card, i) => {
+          return (
+            <img
+              card={card}
+              onClick={() => handleOpenModal(card.id, i)}
+              alt="item"
+              src={card.image}
+              key={i}
+            />
+          );
+        })}
+      </div>
+      {isModalActive && cardData.length > 0 && (
+        <Modal
+          handleModal={handleModal}
+          cardData={cardData}
+          setCardData={setCardData}
+          cardIndex={cardIndex}
+          setCardIndex={setCardIndex}
+          handleIndex={handleIndex}
+          cardLength={cardData.length}
+          photoId={photoId}
+        />
+      )}
+    </>
+  );
 };
 
 export default withRouter(Main);

--- a/src/Pages/Main/TempCard.js
+++ b/src/Pages/Main/TempCard.js
@@ -1,0 +1,52 @@
+import React from "react";
+import styled from "styled-components";
+import CardTopBtns from "../../Component/Card/CardTopBtns";
+import CardUser from "../../Component/Card/CardUser";
+
+const TempCard = ({ card }) => {
+  const height = (card.height * 416) / card.width;
+  return (
+    <CardFrame height={Math.round(height, 0)}>
+      <div className="hover">
+        <CardTopBtns data={card} />
+        <CardUser data={card} />
+      </div>
+      <img alt="imageCard" src={card.image} />
+    </CardFrame>
+  );
+};
+
+export default TempCard;
+
+const CardFrame = styled.figure`
+  position: relative;
+  display: inline-block;
+  width: 416px;
+  height: ${(props) => `${props.height}px`};
+  margin-bottom: 23px;
+  cursor: zoom-in;
+
+  .hover {
+    opacity: 0;
+    position: absolute;
+    display: flex;
+    justify-content: space-between;
+    align-self: flex-start;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.3);
+    transition: 0.2s;
+
+    &:hover {
+      opacity: 1;
+      transition: 0.2s;
+    }
+  }
+
+  img {
+    width: 100%;
+    vertical-align: middle;
+  }
+`;

--- a/src/Pages/Topic/Card.js
+++ b/src/Pages/Topic/Card.js
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import CardTopBtns from "./CardTopBtns";
+import CardUser from "./CardUser";
+
+const Card = ({ card, color, id, onClickModal, isModalActive }) => {
+  const [show, setShow] = useState(false);
+  const height = (card.height * 416) / card.width;
+
+  const options = { thershold: 1.0 };
+  const observer = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        observer.unobserve(entry.target);
+        entry.target.backgroundColor = entry.target.color;
+      }
+    });
+  }, options);
+  document.querySelectorAll(".imageCard").forEach((img) => {
+    observer.observe(img);
+  });
+
+  return (
+    // <CardFrame color={color[id]}>
+    <CardFrame onClick={() => onClickModal(card.id, id)}>
+      {
+        <div
+          onMouseEnter={() => setShow(true)}
+          onMouseLeave={() => setShow(false)}
+        >
+          {show && (
+            <div className="hover">
+              <CardTopBtns data={card} img={card.image} id={id} />
+              <CardUser isModalActive={isModalActive} data={card} />
+            </div>
+          )}
+          <img alt="" className="imageCard" src={card.image} color={color} />
+        </div>
+      }
+    </CardFrame>
+  );
+};
+
+export default Card;
+
+const CardFrame = styled.figure`
+  position: relative;
+  display: inline-block;
+  width: 416px;
+  height: ${(props) => `${props.height}px`};
+  margin-bottom: 23px;
+  cursor: zoom-in;
+
+  .hover {
+    position: absolute;
+    display: flex;
+    justify-content: space-between;
+    align-self: flex-start;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.3);
+    transition: 0.2s;
+  }
+
+  .imageCard {
+    display: block;
+    width: 100%;
+    height: ${(props) => `${props.height}px`};
+    background-color: ${(props) => props.color};
+  }
+`;

--- a/src/Pages/Topic/Topic.js
+++ b/src/Pages/Topic/Topic.js
@@ -1,14 +1,23 @@
 import React from "react";
+import styled from "styled-components";
+import Nav from "../../Component/Nav/Nav";
 import TopicInfo from "../../Component/TopicInfo";
 import CardList from "../../Component/Card/CardList";
 
 const Topic = () => {
   return (
     <>
-      <TopicInfo />
-      <CardList />
+      <Nav />
+      <TopicFrame>
+        <TopicInfo />
+        <CardList />
+      </TopicFrame>
     </>
   );
 };
 
 export default Topic;
+
+const TopicFrame = styled.div`
+  margin-top: 124px;
+`;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,19 +1,18 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import Nav from "./Component/Nav/Nav";
+// import Nav from "./Component/Nav/Nav";
 import Main from "./Pages/Main/Main";
 import Topic from "./Pages/Topic/Topic";
-import Login from "./Pages/Login/Login";
+// import Login from "./Pages/Login/Login";
 
 class Routes extends React.Component {
   render() {
     return (
       <Router>
-        <Nav />
         <Switch>
           <Route exact path="/" component={Main} />
-          <Route exact path="/CardList" component={Topic} />
-          <Route exact path="/Login" component={Login} />
+          <Route exact path="/Topic" component={Topic} />
+          {/* <Route exact path="/Login" component={Login} /> */}
         </Switch>
       </Router>
     );

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,2 @@
+const API_URL = "http://10.58.1.242:8000";
+export default API_URL;


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약
 -Photo Card를 클릭할 경우 뜨는 상세 모달 창 구현
 -CardList & Card & Modal 컴포넌트 연동 작업
 -Collections Modal 기본 틀 완성
		 
## 수정 사항들 자세한 내용
 ▪︎Component 구조 개선
  -모달 창 스크롤 OK
  -모달 창 왼쪽 상단 버튼 및 바깥 Padding부분 클릭 시 창 닫힘 기능 구현 완료
  -다음 창, 이전 창 버튼 조작 기능 구현 완료 (가장 처음&마지막 오류 예외처리 OK

 ▪︎서버와 1차 테스트 완료
  -CardList페이지에서 받아온 데이터(가정)로 모달 창 슬라이드 구현  OK
  -각 상품의 id로 CardDetail Api call 1차 테스트 OK

<추가 2020/08/09>

▪︎서버와 Related photos 및 collections 부분까지 테스트 진행
 
▪︎모달 창 상태 관리 개선
 -새 이미지가 뜰 경우 모달 창 가장 상단으로 이동 및 이미지 사이즈 원 상태로 복귀
 -새 창이 뜰 경우 related photos가 담긴 배열 초기화 (추후 스켈레톤 구현예정)

<추가 2020/08/11>

▪︎CardList 및 Card 컴포넌트 merge 후 상세 모달 창과 연동
 -CardList에서 state관리를 통해  Modal창 랜더
 -Card컴포넌트 내부로 모달 창 오픈 onClick이벤트 이동

▪︎Collection Modal창 기본 위치 잡기
 -Card컴포넌트에서 +버튼 클릭시 CollectionModal 페이지가 뜰 수 있도록 지윤님과 작업

▪︎Card컴포넌트 구조 개선
 -지윤님과 Card컴포넌트 구조 개선 작업(각각의 버튼들이 개별적으로 클릭이 가능)


## 기타 질문 및 특이 사항
모달 창 스크롤을 하고 다음 모달 창으로 넘어 갔을 때, 다음 페이지의 가장 상단이 보이게 하고 싶으나, 방법을 찾는 중.
window.scrollTo(0, 0); 적용 실패,, => 성공!🙆‍♀️

<추가 2020/08/11> 
👀질문입니당!
⭐️⭐️⭐️⭐️⭐️Unsplash페이지에서 여러 모달 창을 띄우고 있는데, 각각의 컴포넌트들이 서로 전달하는 props와 function들이 너무 많은 것 같아 구조에 문제가 있는건 아닌가라는 생각이 듭니다. 혹시 구조 개선이 필요한 부분이 있다면 조언 부탁드립니다.⭐️⭐️⭐️⭐️⭐️

 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
